### PR TITLE
docs(README): add pre-commit badge. [no ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <p align="left">
   <a href="https://github.com/pabroux/stargazer/blob/master/LICENSE"><img src="https://img.shields.io/github/license/pabroux/stargazer.svg?label=License" alt="License Badge"></a>
+  <a href="https://github.com/pre-commit/pre-commit"><img src="https://img.shields.io/badge/pre--commit-enabled-green?logo=pre-commit" alt="pre-commit Badge"></a>
   <a href="https://github.com/pabroux/stargazer/actions/workflows/ci.yml"><img src="https://github.com/pabroux/stargazer/actions/workflows/ci.yml/badge.svg" alt="CI Badge"></a>
 </p>
 


### PR DESCRIPTION
Adding a pre-commit badge to the README to inform the community.